### PR TITLE
[CRITICAL] State restoration fails in `Prefetcher` due to mutable state aliasing in `_populate_queue`

### DIFF
--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import queue
 import threading
 from typing import Any, Dict, Optional, Union
@@ -75,7 +76,7 @@ def _populate_queue(
             yielded += 1
             snapshot = None
             if snapshot_frequency > 0 and yielded % snapshot_frequency == 0:
-                snapshot = source.state_dict()
+                snapshot = copy.deepcopy(source.state_dict())
             _put(item, block=False, snapshot=snapshot)
         except StopIteration as e:
             _put(e, block=False)

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -76,7 +76,9 @@ def _populate_queue(
             yielded += 1
             snapshot = None
             if snapshot_frequency > 0 and yielded % snapshot_frequency == 0:
-                snapshot = copy.deepcopy(source.state_dict())
+                snapshot = source.state_dict()
+                if snapshot is not None:
+                    snapshot = copy.deepcopy(snapshot)
             _put(item, block=False, snapshot=snapshot)
         except StopIteration as e:
             _put(e, block=False)

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -61,7 +61,10 @@ def _populate_queue(
         assert (
             isinstance(snapshot_frequency, int) and snapshot_frequency >= 0
         ), f"snapshot_frequency must be non-negative integer! Got {snapshot_frequency}"
-        snapshot_store.append_initial_snapshot(snapshot=source.state_dict())
+        snapshot = source.state_dict()
+        if snapshot is not None:
+            snapshot = copy.deepcopy(snapshot)
+        snapshot_store.append_initial_snapshot(snapshot=snapshot)
     except Exception:
         e = StartupExceptionWrapper(where="in _populate_queue startup for device")
         snapshot_store.append_initial_snapshot(snapshot=e)


### PR DESCRIPTION
I encountered an issue where data pipeline restoration does not work correctly when using `Prefetcher`. I identified a temporal aliasing bug (a code-order race condition) regarding `state_dict()` manipulation.

`torchdata` does not strictly enforce immutability on `get_state()`, meaning nodes can return nested mutable structures (lists, dicts, etc.). Because the snapshot is not deeply copied, it is mutated in place as the pipeline continues to yield items.

### Reproduction Steps

In `_populate_queue`, a single worker thread executes the following loop sequentially:

1. Calls `next(source)`.
2. Calls `snapshot = source.state_dict()`, which exposes references to the internal states of upstream nodes (lists, dicts, buffers, etc.).
3. Places `snapshot` into the `SnapshotStore`.
4. Loops back to step 1 and calls `next(source)` again. **[!]** Internal buffers of the underlying nodes get updated, which silently mutates the referenced state already sitting in the `SnapshotStore`.
5. When the snapshot is later extracted from the `SnapshotStore` (e.g., by the main thread), it is inconsistent and reflects future states.

This leads to the inability to resume any complex pipeline that relies on `Prefetcher` and stateful upstream nodes.

### Proposed Solution

The safest and most robust fix is to enforce a deep copy when taking the snapshot before placing it in the store. Updating step 2 to:

```python
import copy
snapshot = copy.deepcopy(source.state_dict())

```

This isolates the saved state and prevents the worker thread's subsequent `next(source)` calls from corrupting the stored snapshot.

### Reproduction

```python
import time
from typing import Any, Dict, Optional
from torchdata.nodes.base_node import BaseNode
# Assuming Prefetcher is importable from your local module / torchdata
from torchdata.nodes import Prefetcher 

class MutableSource(BaseNode[int]):
    """A dummy source node with a mutable state dict to demonstrate aliasing."""
    def __init__(self, num_items: int = 10):
        super().__init__()
        self.num_items = num_items
        self.state = {"index": 0}  # Mutable dictionary

    def reset(self, initial_state: Optional[Dict[str, Any]] = None):
        super().reset(initial_state)
        if initial_state is not None:
            self.state = initial_state
        else:
            self.state = {"index": 0}

    def next(self) -> int:
        if self.state["index"] >= self.num_items:
            raise StopIteration()
        
        val = self.state["index"]
        self.state["index"] += 1
        return val

    def get_state(self) -> Dict[str, Any]:
        # Returns a reference to the mutable dict, NOT a deepcopy
        return self.state


def reproduce_aliasing_bug():
    source = MutableSource(num_items=10)
    # prefetch_factor > 0 allows the worker thread to run ahead
    prefetcher = Prefetcher(source, prefetch_factor=3, snapshot_frequency=1)
    prefetcher.reset()

    # 1. Pull the very first item (0)
    print(f"Step 1: Yielded item -> {prefetcher.next()}")

    # 2. Extract the state immediately
    saved_state = prefetcher.get_state()
    snapshot = saved_state["snapshot"]
    print(f"Step 2: Snapshot internal index immediately after extraction -> {snapshot['index']}")

    # 3. Give the background worker thread a moment to prefetch the next few items
    print("Step 3: Waiting 0.5s for the background worker thread to prefetch...")
    time.sleep(0.5)

    # 4. Check the exact same snapshot object in memory again
    print(f"Step 4: Snapshot internal index after background prefetch -> {snapshot['index']}  <-- [BUG! State mutated]")

    # 5. Attempt to restore from the corrupted state
    print("\n--- Restoring from saved_state ---")
    new_source = MutableSource(num_items=10)
    new_prefetcher = Prefetcher(new_source, prefetch_factor=3, snapshot_frequency=1)
    new_prefetcher.reset(saved_state)

    # Because the state was mutated by the worker thread, it will skip elements
    next_item = new_prefetcher.next()
    print(f"Restored Yield: Expected 1, but got -> {next_item}")


if __name__ == "__main__":
    reproduce_aliasing_bug()
```

This reproduces the bug on the latest release but not with the fix.