### PR TITLE
Fix Loader restoration before None items

### DIFF
--- a/test/nodes/test_loader.py
+++ b/test/nodes/test_loader.py
@@ -53,3 +53,14 @@ class TestLoader(TestCase):
         length = 10
         node = MapStyleWrapper(DummyMapDataset(length), sampler=range(length))
         self._test_loader_correct_state_dict_at_midpoint(node, length)
+
+    def test_loader_restores_before_none_item(self) -> None:
+        loader = Loader(IterableWrapper([0, None, 2]))
+        iterator = iter(loader)
+        self.assertEqual(next(iterator), 0)
+        state_dict = loader.state_dict()
+
+        restored = Loader(IterableWrapper([0, None, 2]))
+        restored.load_state_dict(state_dict)
+
+        self.assertEqual(list(restored), [None, 2])

--- a/test/nodes/test_loader.py
+++ b/test/nodes/test_loader.py
@@ -64,3 +64,15 @@ class TestLoader(TestCase):
         restored.load_state_dict(state_dict)
 
         self.assertEqual(list(restored), [None, 2])
+
+    def test_loader_reset_clears_cached_state_dict(self) -> None:
+        checkpoint_source = Loader(IterableWrapper([0, 1, 2]))
+        self.assertEqual(next(iter(checkpoint_source)), 0)
+        state_dict = checkpoint_source.state_dict()
+
+        loader = Loader(IterableWrapper([0, 1, 2]))
+        self.assertTrue(iter(loader).has_next())
+        loader.load_state_dict(state_dict)
+        iter(loader)
+
+        self.assertEqual(loader.state_dict(), state_dict)

--- a/torchdata/nodes/loader.py
+++ b/torchdata/nodes/loader.py
@@ -112,6 +112,7 @@ class LoaderIterator(BaseNode[T]):
             self._num_yielded = 0
         self._cached_item = None
         self._has_cached_item = False
+        self._cached_state_dict = None
 
     def has_next(self) -> bool:
         if not self._has_cached_item:

--- a/torchdata/nodes/loader.py
+++ b/torchdata/nodes/loader.py
@@ -98,6 +98,7 @@ class LoaderIterator(BaseNode[T]):
         self.loader = loader
         self.root = loader.root
         self._cached_item = None
+        self._has_cached_item = False
         self._cached_state_dict: Optional[Dict[str, Any]] = None
         self._num_yielded = 0
 
@@ -110,22 +111,25 @@ class LoaderIterator(BaseNode[T]):
             self.root.reset(None)
             self._num_yielded = 0
         self._cached_item = None
+        self._has_cached_item = False
 
     def has_next(self) -> bool:
-        if self._cached_item is None:
+        if not self._has_cached_item:
             try:
                 # Cache the current state dict
                 self._cached_state_dict = self.state_dict()
                 # Load and save the next item
                 self._cached_item = next(self)
+                self._has_cached_item = True
             except StopIteration:
                 pass
-        return self._cached_item is not None
+        return self._has_cached_item
 
     def next(self):
-        if self._cached_item is not None:
+        if self._has_cached_item:
             item = self._cached_item
             self._cached_item = None
+            self._has_cached_item = False
             self._cached_state_dict = None
         else:
             item = next(self.root)


### PR DESCRIPTION
Fixes #1551.

### Summary

`LoaderIterator` used `None` both as a valid data value and as the empty look-ahead marker. When a checkpoint resumed immediately before a `None` item, `Loader.__iter__()` called `has_next()`, misclassified the item as end-of-input, and reset the pipeline to the beginning. This duplicated all data consumed before the checkpoint.

This change tracks cache occupancy separately from the cached value. `None` can therefore be cached and returned like any other item, while the existing look-ahead and restart behavior remains unchanged for exhausted iterators.

Reset now also clears the cached prefetch state dictionary together with the cached item. This prevents `state_dict()` from reporting a position captured before a later `load_state_dict()` and iterator reset.

The regressions verify that restoring `[0, None, 2]` after consuming `0` yields exactly `[None, 2]`, and that a state request after `has_next()`, `load_state_dict()`, and `iter(loader)` reports the restored position.

### Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13 -m pytest -q test/nodes/test_loader.py` (5 passed)
- `py -3.13 -m pre_commit run --files torchdata/nodes/loader.py test/nodes/test_loader.py` (passed)
- Direct public-flow probe: the stale-state regression failed before the reset fix with positions 0 and 1, then passed after the fix.
- `git diff --check` (passed)
- Standalone mypy was not used as a final signal because the installed version rejects the repository's quoted `python_version` setting and this source checkout lacks the generated `torchdata.version` module.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.